### PR TITLE
this adds the serw12 to the supported models/2

### DIFF
--- a/kcc_cli/keyboard_backlight.py
+++ b/kcc_cli/keyboard_backlight.py
@@ -16,6 +16,7 @@ class KeyboardBacklight:
         'oryp6': ONE_BACKLIGHT_PATH,
         'oryp4': FOUR_BACKLIGHT_PATH,
         'serw11': FOUR_BACKLIGHT_PATH,
+	'serw12': FOUR_BACKLIGHT_PATH,
         # More to come
     }
 


### PR DESCRIPTION
This just adds the serw12 to the support model list based on this output:

`❯ ls /sys/class/leds
input30::capslock  input30::numlock	input4::numlock     system76::airplane
input30::compose   input30::scrolllock	input4::scrolllock  system76::kbd_backlight
input30::kana	   input4::capslock	phy0-led

❯ ls /sys/class/leds/system76::kbd_backlight
brightness	       color_center  color_left   device	  power      trigger
brightness_hw_changed  color_extra   color_right  max_brightness  subsystem  uevent
`