### PR TITLE
Specify Gtk version

### DIFF
--- a/keyboard-color-switcher.py
+++ b/keyboard-color-switcher.py
@@ -4,6 +4,7 @@ import sys
 from typing import Tuple
 
 import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gio
 
 from kcc_cli.keyboard_backlight import KeyboardBacklight


### PR DESCRIPTION
Fixes:
```
keyboard-color-switcher/keyboard-color-switcher.py:7: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
```

Now I can install Gtk 4 again.