### PR TITLE
Add darp5

### DIFF
--- a/kcc_cli/backlight_paths.py
+++ b/kcc_cli/backlight_paths.py
@@ -1,10 +1,5 @@
 from kcc_cli.enums import Position
 
-SINGLE_BACKLIGHT_PATH = {
-    'brightness_path': '/sys/class/leds/system76::kbd_backlight/brightness',
-    'brightness_color': {
-        Position.CENTER: '/sys/class/leds/system76::kbd_backlight/color_left'
-    }
 
 ONE_BACKLIGHT_PATH = {
     'brightness_path': '/sys/class/leds/system76_acpi::kbd_backlight/brightness',
@@ -21,5 +16,12 @@ FOUR_BACKLIGHT_PATH = {
         Position.CENTER: '/sys/class/leds/system76::kbd_backlight/color_center',
         Position.RIGHT: '/sys/class/leds/system76::kbd_backlight/color_right',
         Position.EXTRA: '/sys/class/leds/system76::kbd_backlight/color_extra',
+    }
+}
+
+SINGLE_BACKLIGHT_PATH = {
+    'brightness_path': '/sys/class/leds/system76::kbd_backlight/brightness',
+    'brightness_color': {
+        Position.CENTER: '/sys/class/leds/system76::kbd_backlight/color_left'
     }
 }

--- a/kcc_cli/backlight_paths.py
+++ b/kcc_cli/backlight_paths.py
@@ -1,5 +1,10 @@
 from kcc_cli.enums import Position
 
+SINGLE_BACKLIGHT_PATH = {
+    'brightness_path': '/sys/class/leds/system76::kbd_backlight/brightness',
+    'brightness_color': {
+        Position.CENTER: '/sys/class/leds/system76::kbd_backlight/color_left'
+    }
 
 ONE_BACKLIGHT_PATH = {
     'brightness_path': '/sys/class/leds/system76_acpi::kbd_backlight/brightness',

--- a/kcc_cli/keyboard_backlight.py
+++ b/kcc_cli/keyboard_backlight.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from kcc_cli.common import read_file, write_file
 from kcc_cli.enums import Position, Mode
-from kcc_cli.backlight_paths import ONE_BACKLIGHT_PATH, FOUR_BACKLIGHT_PATH
+from kcc_cli.backlight_paths import ONE_BACKLIGHT_PATH, FOUR_BACKLIGHT_PATH, SINGLE_BACKLIGHT_PATH
 
 
 def get_laptop_model() -> str:
@@ -13,6 +13,7 @@ def get_laptop_model() -> str:
 
 class KeyboardBacklight:
     MODEL_NUMBER_BACKLIGHT_MAPPING = {
+        'darp5': SINGLE_BACKLIGHT_PATH,
         'oryp6': ONE_BACKLIGHT_PATH,
         'oryp4': FOUR_BACKLIGHT_PATH,
         'serw11': FOUR_BACKLIGHT_PATH,


### PR DESCRIPTION
This adds the support for the darp5. My only concern is the SINGLE versus ONE since the oryp6 has a SINGLE path as well though it uses ACPI instead. 